### PR TITLE
fix:[バグ] - サークル詳細のタブ遷移の修正

### DIFF
--- a/components/disclosure/circle-detail-tabs.tsx
+++ b/components/disclosure/circle-detail-tabs.tsx
@@ -19,8 +19,7 @@ import {
   Text,
   useSnacks,
 } from "@yamada-ui/react"
-import { useRouter } from "next/navigation"
-import { useState } from "react"
+import Link from "next/link"
 import { MemberRequestCard } from "../data-display/member-request-card"
 import type { getMembershipRequests } from "@/actions/circle/membership-request"
 import type { getCircleById } from "@/data/circle"
@@ -58,40 +57,25 @@ export const CircleDetailTabs: FC<CircleDetailTabsProps> = ({
   isAdmin,
   fetchData,
 }) => {
-  const [tabIndex, setTabIndex] = useState(handlingTab(tabKey || ""))
+  const tabIndex = handlingTab(tabKey || "")
   const { data } = membershipRequests
   const { snack, snacks } = useSnacks()
   const handleSnack = (title: string, status: AlertStatus) =>
     snack({ title, status })
 
-  const router = useRouter()
-  const handleChange = (index: number) => {
-    setTabIndex(index)
-    switch (index) {
-      case 0:
-        router.push(`/circles/${circle?.id}/days`)
-        break
-      case 1:
-        router.push(`/circles/${circle?.id}/images`)
-        break
-      case 2:
-        router.push(`/circles/${circle?.id}/notifications`)
-        break
-      case 3:
-        router.push(`/circles/${circle?.id}/members`)
-        break
-
-      default:
-        break
-    }
-  }
   return (
-    <Tabs index={tabIndex} onChange={handleChange}>
+    <Tabs index={tabIndex}>
       <TabList overflowX="auto">
-        <Tab flexShrink={0}>活動日程</Tab>
-        <Tab flexShrink={0}>画像</Tab>
-        <Tab flexShrink={0}>掲示板</Tab>
-        <Tab flexShrink={0}>
+        <Tab as={Link} href={`/circles/${circle?.id}/days`}>
+          活動日程
+        </Tab>
+        <Tab as={Link} href={`/circles/${circle?.id}/images`}>
+          画像
+        </Tab>
+        <Tab as={Link} href={`/circles/${circle?.id}/notifications`}>
+          掲示板
+        </Tab>
+        <Tab as={Link} href={`/circles/${circle?.id}/members`}>
           <Indicator
             colorScheme="danger"
             size="sm"


### PR DESCRIPTION
Closes #62 <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
circle-detail-tabs.tsx内のタブ移動で、handleChange関数内でページ遷移するとタブ切り替えからページ遷移まで遅延が発生する場合もあるので、Tabをリンク化してタブとページの切り替えをひとまとめにする

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
