### PR TITLE
fix: サークル名と説明の文字数制限

### DIFF
--- a/components/data-display/activity-card.tsx
+++ b/components/data-display/activity-card.tsx
@@ -51,7 +51,9 @@ export const ActivityCard: FC<ActivityCardProps> = ({
             alignItems={{ md: "start" }}
           >
             <Text>内容:</Text>
-            <Text as="pre">{currentActivity.description}</Text>
+            <Text text-wrap="auto" whiteSpace="pre-wrap">
+              {currentActivity.description}
+            </Text>
           </HStack>
           <HStack
             flexDir={{ base: "row", md: "column" }}
@@ -89,7 +91,9 @@ export const ActivityCard: FC<ActivityCardProps> = ({
             alignItems={{ md: "start" }}
           >
             <Text>備考:</Text>
-            <Text as="pre">{currentActivity.notes}</Text>
+            <Text text-wrap="auto" whiteSpace="pre-wrap">
+              {currentActivity.notes}
+            </Text>
           </HStack>
         </VStack>
       </CardBody>

--- a/components/data-display/activity-card.tsx
+++ b/components/data-display/activity-card.tsx
@@ -50,7 +50,7 @@ export const ActivityCard: FC<ActivityCardProps> = ({
             flexDir={{ base: "row", md: "column" }}
             alignItems={{ md: "start" }}
           >
-            <Text>内容:</Text>
+            <Text whiteSpace="nowrap">内容:</Text>
             <Text text-wrap="auto" whiteSpace="pre-wrap">
               {currentActivity.description}
             </Text>
@@ -59,25 +59,20 @@ export const ActivityCard: FC<ActivityCardProps> = ({
             flexDir={{ base: "row", md: "column" }}
             alignItems={{ md: "start" }}
           >
-            <HStack
-              flexDir={{ base: "row", md: "column" }}
-              alignItems={{ md: "start" }}
-            >
-              <Text>活動時間:</Text>
-              <Text>
-                {displayTime(currentActivity.startTime)}
-                {currentActivity.endTime
-                  ? `～${displayTime(currentActivity.endTime)}`
-                  : undefined}
-              </Text>
-            </HStack>
-            <HStack
-              flexDir={{ base: "row", md: "column" }}
-              alignItems={{ md: "start" }}
-            >
-              <Text>活動場所:</Text>
-              <Text>{currentActivity.location}</Text>
-            </HStack>
+            <Text>活動時間:</Text>
+            <Text>
+              {displayTime(currentActivity.startTime)}
+              {currentActivity.endTime
+                ? `～${displayTime(currentActivity.endTime)}`
+                : undefined}
+            </Text>
+          </HStack>
+          <HStack
+            flexDir={{ base: "row", md: "column" }}
+            alignItems={{ md: "start" }}
+          >
+            <Text>活動場所:</Text>
+            <Text>{currentActivity.location}</Text>
           </HStack>
           <HStack
             flexDir={{ base: "row", md: "column" }}
@@ -90,7 +85,7 @@ export const ActivityCard: FC<ActivityCardProps> = ({
             flexDir={{ base: "row", md: "column" }}
             alignItems={{ md: "start" }}
           >
-            <Text>備考:</Text>
+            <Text whiteSpace="nowrap">備考:</Text>
             <Text text-wrap="auto" whiteSpace="pre-wrap">
               {currentActivity.notes}
             </Text>

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -157,7 +157,7 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                   alignItems={{ md: "start" }}
                 >
                   <Text>内容:</Text>
-                  <Text as="pre">{currentActivity.description}</Text>
+                  <Text text-wrap="auto">{currentActivity.description}</Text>
                 </HStack>
                 <HStack
                   flexDir={{ base: "row", md: "column" }}
@@ -195,7 +195,7 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                   alignItems={{ md: "start" }}
                 >
                   <Text>備考:</Text>
-                  <Text as="pre">{currentActivity.notes}</Text>
+                  <Text text-wrap="auto">{currentActivity.notes}</Text>
                 </HStack>
               </VStack>
             </CardBody>

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -241,11 +241,11 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                           >
                             {activity.activityDay.getDate()}
                           </Card>
-                          <Text>{activity.title}</Text>
+                          <Text lineClamp={1}>{activity.title}</Text>
                         </HStack>
 
                         <HStack>
-                          <Text>{activity.location}</Text>
+                          <Text lineClamp={1}>{activity.location}</Text>
                           <Text>
                             {displayTime(activity.startTime)}
                             {activity.endTime

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -180,7 +180,9 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                               ? `～${displayTime(activity.endTime)}`
                               : undefined}
                           </Text>
-                          <Text>{activity.participants.length}人</Text>
+                          <Text whiteSpace="nowrap">
+                            {activity.participants.length}人
+                          </Text>
                           <ActivityMenuButton
                             userId={userId}
                             isMember={!!isMember}

--- a/schema/activity.ts
+++ b/schema/activity.ts
@@ -10,7 +10,7 @@ export const ActivitySchema = z.object({
   // 任意項目: 内容
   description: z
     .string()
-    .max(100, { message: "100文字以下にしてください。" })
+    .max(200, { message: "200文字以下にしてください。" })
     .optional(),
   // 必須項目: 日付
   date: z.date({ required_error: "日付を設定してください。" }),

--- a/schema/activity.ts
+++ b/schema/activity.ts
@@ -8,17 +8,26 @@ export const ActivitySchema = z.object({
     .min(1, { message: "活動タイトルは必須です。" })
     .max(30, { message: "30文字以下にしてください。" }),
   // 任意項目: 内容
-  description: z.string().optional(),
+  description: z
+    .string()
+    .max(100, { message: "100文字以下にしてください。" })
+    .optional(),
   // 必須項目: 日付
   date: z.date({ required_error: "日付を設定してください。" }),
   // 任意項目: 場所
-  location: z.string().optional(),
+  location: z
+    .string()
+    .max(20, { message: "20文字以下にしてください。" })
+    .optional(),
   // 必須項目: 開始時間 (時刻フォーマット)
   startTime: z.string().min(1, { message: "開始時間を設定してください。" }),
   // 任意項目: 終了時間 (時刻フォーマット)
   endTime: z.string().optional(),
   // 任意項目: 備考
-  notes: z.string().optional(),
+  notes: z
+    .string()
+    .max(100, { message: "100文字以下にしてください。" })
+    .optional(),
 })
 
 export type ActivityFormType = z.infer<typeof ActivitySchema>

--- a/schema/circle.ts
+++ b/schema/circle.ts
@@ -15,8 +15,14 @@ export const CircleSchema = z.object({
   instructors: z
     .array(z.string())
     .nonempty("講師を少なくとも一人選択してください"), // 講師は文字列配列
-  location: z.string().min(1, { message: "活動場所は必須です。" }), // 活動場所は必須
-  activityDay: z.string().min(1, { message: "活動日は必須です。" }), // 活動日は必須
+  location: z
+    .string()
+    .min(1, { message: "活動場所は必須です。" })
+    .max(20, { message: "20文字以下にしてください。" }), // 活動場所は必須
+  activityDay: z
+    .string()
+    .min(1, { message: "活動日は必須です。" })
+    .max(10, { message: "10文字以下にしてください。" }), // 活動日は必須
 })
 
 // フロントエンド用のスキーマ

--- a/schema/circle.ts
+++ b/schema/circle.ts
@@ -2,8 +2,16 @@ import { z } from "zod"
 
 // 共通の基本スキーマ（バックエンドでも使用）
 export const CircleSchema = z.object({
-  name: z.string().trim().min(1, { message: "サークル名は必須です。" }), // サークル名は必須
-  description: z.string().trim().min(1, { message: "説明は必須です。" }), // 説明は必須
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: "サークル名は必須です。" })
+    .max(30, { message: "30文字以下にしてください。" }), // サークル名は必須
+  description: z
+    .string()
+    .trim()
+    .min(1, { message: "説明は必須です。" })
+    .max(100, { message: "100文字以下にしてください。" }), // 説明は必須
   instructors: z
     .array(z.string())
     .nonempty("講師を少なくとも一人選択してください"), // 講師は文字列配列


### PR DESCRIPTION
Related #15, #7 

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
サークル作成・編集時のサークル名と説明で文字数制限を行うように修正

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- サークル名：上限30文字
- 説明：上限100文字

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
![image](https://github.com/user-attachments/assets/310faf64-f4a2-431e-8693-dffd52f9b259)
活動日程の内容・場所・備考も文字数の上限ある方がいいかも？