### PR TITLE
fix: アルバムの文字数制限と改行表示

### DIFF
--- a/components/data-display/album-card.tsx
+++ b/components/data-display/album-card.tsx
@@ -76,7 +76,9 @@ export const AlbumCard: FC<AlbumCard> = ({
             ) : undefined}
           </HStack>
         </HStack>
-        <Text as="pre">{currentAlbum.description}</Text>
+        <Text as="pre" textWrap="wrap">
+          {currentAlbum.description}
+        </Text>
       </VStack>
     </HStack>
   )

--- a/components/data-display/circle-albums.tsx
+++ b/components/data-display/circle-albums.tsx
@@ -161,7 +161,7 @@ export const CircleAlbums: FC<CircleAlbums> = ({
                       ) : undefined}
                     </HStack>
                   </HStack>
-                  <Text as="pre" textWrap="wrap">
+                  <Text as="pre" textWrap="wrap" lineClamp={3}>
                     {album.description}
                   </Text>
                 </VStack>

--- a/schema/album.ts
+++ b/schema/album.ts
@@ -40,7 +40,11 @@ export const AlbumFormSchema = z.object({
     .trim()
     .min(1, { message: "タイトルは必須です。" })
     .max(20, { message: "20文字以下にしてください。" }),
-  description: z.string().trim().min(1, { message: "内容は必須です。" }),
+  description: z
+    .string()
+    .trim()
+    .min(1, { message: "内容は必須です。" })
+    .max(1000, { message: "1000文字以下にしてください。" }),
 })
 
 export const FrontAlbumFormSchema = AlbumFormSchema.extend({

--- a/schema/album.ts
+++ b/schema/album.ts
@@ -35,7 +35,11 @@ export const AlbumImageSchema = z
 
 // フロントエンド用スキーマ
 export const AlbumFormSchema = z.object({
-  title: z.string().trim().min(1, { message: "タイトルは必須です。" }),
+  title: z
+    .string()
+    .trim()
+    .min(1, { message: "タイトルは必須です。" })
+    .max(20, { message: "20文字以下にしてください。" }),
   description: z.string().trim().min(1, { message: "内容は必須です。" }),
 })
 


### PR DESCRIPTION
Related #121  <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
アルバムのタイトルと内容で文字数制限を行うように修正
その他レイアウト崩れの修正
## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
アルバムタイトル：上限20文字
アルバム内容：上限1000文字
- アルバム一覧での内容表示を全行→3行に変更
- アルバム詳細を開いたときに画面に合わせて内容が改行されるように変更
## 追加情報

<!-- その他で記述する情報があれば書いてください -->
アルバム一覧で、タイトルの文字数によって日時・三点リーダの表示位置が変わるの気になるかも
余裕があれば修正する