### PR TITLE
ユーザープロフィール機能実装

### DIFF
--- a/actions/user/user.ts
+++ b/actions/user/user.ts
@@ -1,5 +1,36 @@
 "use server"
+import { auth } from "@/auth"
+import { updateUser } from "@/data/user"
+import type { BackUserProfileForm } from "@/schema/user"
 import { db } from "@/utils/db"
+
+export const updateUserAction = async (data: BackUserProfileForm) => {
+  const session = await auth()
+  const user = await getUserById(session?.user?.id || "")
+  if (!session || !user) {
+    return {
+      success: false,
+      error: "ユーザーが存在しません",
+    }
+  }
+  try {
+    const result = await updateUser(
+      user.id,
+      data.profileText || "",
+      data.image || "",
+    )
+    return {
+      success: true,
+      user: result,
+    }
+  } catch (error) {
+    console.error("update user error:", error)
+    return {
+      success: false,
+      error: "プロフィールの更新に失敗しました",
+    }
+  }
+}
 
 export const getUserById = async (id: string) => {
   try {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,8 +106,11 @@ export default async function Home() {
           justifyContent="space-evenly"
         >
           <Avatar
+            as={Link}
+            href={`/user/${session?.user?.id}`}
             src={session?.user?.image || ""}
             boxSize={{ base: "xs", md: "24" }}
+            title="プロフィールへ移動"
           />
           <Heading display={{ base: "none", md: "block" }} fontSize="lg">
             <Text>{user?.studentNumber}</Text>

--- a/app/user/[user_id]/edit/page.tsx
+++ b/app/user/[user_id]/edit/page.tsx
@@ -1,0 +1,54 @@
+import { Center, Text } from "@yamada-ui/react"
+import { notFound } from "next/navigation"
+import { getUserById } from "@/actions/user/user"
+import { auth } from "@/auth"
+import { ProfileForm } from "@/components/forms/profile-form"
+import { getUsers } from "@/data/user"
+
+interface Props {
+  params: { user_id?: string }
+}
+
+export const generateMetadata = async ({ params }: Props) => {
+  const user = await getUserById(params.user_id || "")
+  if (!user) {
+    return {
+      title: "ユーザーがいません",
+    }
+  }
+  return {
+    title: `${user.name}さん プロフィール編集`,
+  }
+}
+
+export const dynamicParams = false
+export const dynamic = "force-dynamic"
+
+export const generateStaticParams = async () => {
+  const users = await getUsers()
+
+  if (!users) {
+    return []
+  }
+
+  return users.map((user) => ({ user_id: user.id }))
+}
+
+const Page = async ({ params }: Props) => {
+  const { user_id: userId } = params
+  const session = await auth()
+  const user = await getUserById(userId || "")
+  if (!user) {
+    notFound()
+  }
+
+  return userId === session?.user?.id ? (
+    <ProfileForm user={user} />
+  ) : (
+    <Center w="full" h="full">
+      <Text>権限がありません</Text>
+    </Center>
+  )
+}
+
+export default Page

--- a/app/user/[user_id]/page.tsx
+++ b/app/user/[user_id]/page.tsx
@@ -1,0 +1,99 @@
+import {
+  Avatar,
+  Button,
+  Card,
+  CardBody,
+  Heading,
+  HStack,
+  Text,
+  VStack,
+} from "@yamada-ui/react"
+import { notFound } from "next/navigation"
+import { getUserById } from "@/actions/user/user"
+import { auth } from "@/auth"
+import { getUsers } from "@/data/user"
+import { MetadataSet } from "@/utils/metadata"
+
+interface Props {
+  params: { user_id?: string }
+}
+
+export const generateMetadata = ({ params }: Props) =>
+  MetadataSet(params.user_id || "", "")
+
+export const dynamicParams = false
+export const dynamic = "force-dynamic"
+
+export const generateStaticParams = async () => {
+  const users = await getUsers()
+
+  if (!users) {
+    return []
+  }
+
+  return users.map((user) => ({ user_id: user.id }))
+}
+
+const Page = async ({ params }: Props) => {
+  const { user_id } = params
+  const session = await auth()
+  const user = await getUserById(user_id || "")
+  if (!user) {
+    notFound()
+  }
+
+  return (
+    <VStack w="full">
+      <HStack>
+        <Avatar src={user?.image || ""} boxSize={{ base: "xs", md: "24" }} />
+        <VStack>
+          <Heading display={{ base: "none", md: "block" }} fontSize="lg">
+            {user?.name}
+          </Heading>
+          <HStack>
+            <Text>{user?.studentNumber}</Text>
+            {user_id === session?.user?.id ? (
+              <Button colorScheme="riverBlue">プロフィール編集</Button>
+            ) : undefined}
+          </HStack>
+        </VStack>
+      </HStack>
+      <Card>
+        <CardBody>
+          <Text as="pre" textWrap="wrap">
+            {user.profileText}
+          </Text>
+        </CardBody>
+      </Card>
+      <Heading as="h3" size="sm">
+        所属サークル
+      </Heading>
+      {/* <Grid
+                gridTemplateColumns={
+                    user.CircleMember?.length
+                        ? {
+                            base: "repeat(3, 1fr)",
+                            xl: "repeat(2, 1fr)",
+                            lg: "repeat(1, 1fr)",
+                            md: "repeat(2, 1fr)",
+                            sm: "repeat(1, 1fr)",
+                        }
+                        : undefined
+                }
+                gap="md"
+                w="full"
+                h="full"
+            >
+                {user.CircleMember?.length ? (
+                    user.CircleMember?.map((data) => <CircleCard key={data.id} data={data.circle} />)
+                ) : (
+                    <Center w="full" h="full" as={VStack}>
+                        <Text>サークルに入っていません</Text>
+                    </Center>
+                )}
+            </Grid> */}
+    </VStack>
+  )
+}
+
+export default Page

--- a/app/user/[user_id]/page.tsx
+++ b/app/user/[user_id]/page.tsx
@@ -17,14 +17,22 @@ import { getUserById } from "@/actions/user/user"
 import { auth } from "@/auth"
 import { CircleCard } from "@/components/data-display/circle-card"
 import { getUsers } from "@/data/user"
-import { MetadataSet } from "@/utils/metadata"
 
 interface Props {
   params: { user_id?: string }
 }
 
-export const generateMetadata = ({ params }: Props) =>
-  MetadataSet(params.user_id || "", "")
+export const generateMetadata = async ({ params }: Props) => {
+  const user = await getUserById(params.user_id || "")
+  if (!user) {
+    return {
+      title: "ユーザーがいません",
+    }
+  }
+  return {
+    title: `${user.name}さんのプロフィール`,
+  }
+}
 
 export const dynamicParams = false
 export const dynamic = "force-dynamic"

--- a/app/user/[user_id]/page.tsx
+++ b/app/user/[user_id]/page.tsx
@@ -82,7 +82,7 @@ const Page = async ({ params }: Props) => {
         </VStack>
       </HStack>
       {user.profileText ? (
-        <Card>
+        <Card bg="white">
           <CardBody>
             <Text as="pre" textWrap="wrap">
               {user.profileText}

--- a/app/user/[user_id]/page.tsx
+++ b/app/user/[user_id]/page.tsx
@@ -70,7 +70,13 @@ const Page = async ({ params }: Props) => {
           <HStack justifyContent="space-between" flexWrap="wrap">
             <Text>{user?.studentNumber}</Text>
             {userId === session?.user?.id ? (
-              <Button colorScheme="riverBlue">プロフィール編集</Button>
+              <Button
+                as={Link}
+                href={`/user/${userId}/edit`}
+                colorScheme="riverBlue"
+              >
+                プロフィール編集
+              </Button>
             ) : undefined}
           </HStack>
         </VStack>

--- a/app/user/[user_id]/page.tsx
+++ b/app/user/[user_id]/page.tsx
@@ -3,14 +3,19 @@ import {
   Button,
   Card,
   CardBody,
+  Center,
+  Grid,
   Heading,
   HStack,
   Text,
   VStack,
 } from "@yamada-ui/react"
+import Link from "next/link"
 import { notFound } from "next/navigation"
+import { getCirclesByUserId } from "@/actions/circle/fetch-circle"
 import { getUserById } from "@/actions/user/user"
 import { auth } from "@/auth"
+import { CircleCard } from "@/components/data-display/circle-card"
 import { getUsers } from "@/data/user"
 import { MetadataSet } from "@/utils/metadata"
 
@@ -35,63 +40,74 @@ export const generateStaticParams = async () => {
 }
 
 const Page = async ({ params }: Props) => {
-  const { user_id } = params
+  const { user_id: userId } = params
   const session = await auth()
-  const user = await getUserById(user_id || "")
+  const user = await getUserById(userId || "")
+  const circles = await getCirclesByUserId(userId || "")
   if (!user) {
     notFound()
   }
 
   return (
-    <VStack w="full">
-      <HStack>
-        <Avatar src={user?.image || ""} boxSize={{ base: "xs", md: "24" }} />
-        <VStack>
-          <Heading display={{ base: "none", md: "block" }} fontSize="lg">
-            {user?.name}
-          </Heading>
-          <HStack>
+    <VStack w="full" h="full" p="md">
+      <HStack
+        w="full"
+        maxW="3xl"
+        m="auto"
+        flexDir={{ base: "row", sm: "column" }}
+      >
+        <Avatar src={user?.image || ""} boxSize={{ base: "2xs", md: "24" }} />
+        <VStack maxW="xl">
+          <Heading fontSize="2xl">{user?.name}</Heading>
+          <HStack justifyContent="space-between" flexWrap="wrap">
             <Text>{user?.studentNumber}</Text>
-            {user_id === session?.user?.id ? (
+            {userId === session?.user?.id ? (
               <Button colorScheme="riverBlue">プロフィール編集</Button>
             ) : undefined}
           </HStack>
         </VStack>
       </HStack>
-      <Card>
-        <CardBody>
-          <Text as="pre" textWrap="wrap">
-            {user.profileText}
-          </Text>
-        </CardBody>
-      </Card>
+      {user.profileText ? (
+        <Card>
+          <CardBody>
+            <Text as="pre" textWrap="wrap">
+              {user.profileText}
+            </Text>
+          </CardBody>
+        </Card>
+      ) : undefined}
       <Heading as="h3" size="sm">
         所属サークル
       </Heading>
-      {/* <Grid
-                gridTemplateColumns={
-                    user.CircleMember?.length
-                        ? {
-                            base: "repeat(3, 1fr)",
-                            xl: "repeat(2, 1fr)",
-                            lg: "repeat(1, 1fr)",
-                            md: "repeat(2, 1fr)",
-                            sm: "repeat(1, 1fr)",
-                        }
-                        : undefined
-                }
-                gap="md"
-                w="full"
-                h="full"
-            >
-                {user.CircleMember?.length ? (
-                    user.CircleMember?.map((data) => <CircleCard key={data.id} data={data.circle} />)
-                ) : (
-                    <Center w="full" h="full" as={VStack}>
-                        <Text>サークルに入っていません</Text>
-                    </Center>
-                )}
-            </Grid> */}
+      <Grid
+        gridTemplateColumns={
+          circles?.length
+            ? {
+                base: "repeat(5, 1fr)",
+                xl: "repeat(4, 1fr)",
+                lg: "repeat(3, 1fr)",
+                md: "repeat(2, 1fr)",
+                sm: "repeat(1, 1fr)",
+              }
+            : undefined
+        }
+        gap="md"
+        w="full"
+        h="full"
+      >
+        {circles?.length ? (
+          circles?.map((data) => <CircleCard key={data.id} data={data} />)
+        ) : (
+          <Center w="full" h="full" as={VStack}>
+            <Text>サークルに入っていません</Text>
+            {userId === session?.user?.id ? (
+              <Button as={Link} href="/circles">
+                サークルを探す
+              </Button>
+            ) : undefined}
+          </Center>
+        )}
+      </Grid>
     </VStack>
   )
 }

--- a/app/user/[user_id]/page.tsx
+++ b/app/user/[user_id]/page.tsx
@@ -57,14 +57,17 @@ const Page = async ({ params }: Props) => {
   }
 
   return (
-    <VStack w="full" h="full" p="md">
+    <VStack w="full" maxW="6xl" h="full" p="md" m="auto">
       <HStack
         w="full"
         maxW="3xl"
         m="auto"
         flexDir={{ base: "row", sm: "column" }}
       >
-        <Avatar src={user?.image || ""} boxSize={{ base: "2xs", md: "24" }} />
+        <Avatar
+          src={user?.image || ""}
+          boxSize={{ base: "2xs", md: "28", sm: "24" }}
+        />
         <VStack maxW="xl">
           <Heading fontSize="2xl">{user?.name}</Heading>
           <HStack justifyContent="space-between" flexWrap="wrap">

--- a/components/data-display/circle-card.tsx
+++ b/components/data-display/circle-card.tsx
@@ -21,7 +21,7 @@ export interface CircleCardProps {
 export const CircleCard = memo(
   forwardRef<CircleCardProps, "div">(({ data }, ref) => {
     return (
-      <GridItem ref={ref} w="full" as={Card} background="white">
+      <GridItem ref={ref} w="full" h="fit-content" as={Card} background="white">
         <LinkBox>
           {data.imagePath ? (
             <Image w="full" h="40" src={data.imagePath} alt="preview image" />

--- a/components/data-display/circle-card.tsx
+++ b/components/data-display/circle-card.tsx
@@ -12,17 +12,10 @@ import {
 } from "@yamada-ui/react"
 import Link from "next/link"
 import { memo } from "react"
+import type { getCirclesByUserId } from "@/actions/circle/fetch-circle"
 
 export interface CircleCardProps {
-  data: {
-    id: string
-    name: string
-    description: string
-    location: string
-    imagePath: string | null
-    activityDay: string | null
-    memberCount: number
-  }
+  data: NonNullable<Awaited<ReturnType<typeof getCirclesByUserId>>>[number]
 }
 
 export const CircleCard = memo(

--- a/components/data-display/member-card.tsx
+++ b/components/data-display/member-card.tsx
@@ -22,6 +22,8 @@ import {
   ModalBody,
   ModalFooter,
   Button,
+  LinkBox,
+  LinkOverlay,
 } from "@yamada-ui/react"
 import { useState, type FC } from "react"
 import type { getCircleById } from "@/actions/circle/fetch-circle"
@@ -95,14 +97,14 @@ export const MemberCard: FC<MemberCard> = ({
 
   return (
     <GridItem w="full" rounded="md" as={Card} bg="white">
-      <CardBody>
+      <CardBody as={LinkBox}>
         <HStack
           as={Center}
           w="full"
           flexWrap="wrap"
           justifyContent="space-between"
         >
-          <HStack flexWrap="wrap">
+          <HStack flexWrap="wrap" as={LinkOverlay} href={`/user/${member.id}`}>
             <Avatar src={member.image || ""} />
             <Badge>{member.role.roleName}</Badge>
             <Text>{member.name}</Text>

--- a/components/data-display/member-request-card.tsx
+++ b/components/data-display/member-request-card.tsx
@@ -11,6 +11,8 @@ import {
   Dialog,
   GridItem,
   HStack,
+  LinkBox,
+  LinkOverlay,
   Text,
   useDisclosure,
 } from "@yamada-ui/react"
@@ -98,14 +100,14 @@ export const MemberRequestCard: FC<MemberRequestCardProps> = ({
         {confirmState === "approve" ? "本当に承認しますか？" : undefined}
         {confirmState === "reject" ? "本当に拒否しますか？" : undefined}
       </Dialog>
-      <CardBody>
+      <CardBody as={LinkBox}>
         <HStack
           as={Center}
           justifyContent="space-between"
           w="full"
           flexWrap="wrap"
         >
-          <HStack flexWrap="wrap">
+          <HStack flexWrap="wrap" as={LinkOverlay} href={`/user/${member.id}`}>
             <Avatar src={member.image || ""} />
             {member.requestType === "join" ? (
               <Badge colorScheme="success">入会</Badge>

--- a/components/forms/profile-form.tsx
+++ b/components/forms/profile-form.tsx
@@ -125,16 +125,16 @@ export const ProfileForm: FC<ProfileForm> = ({ user }) => {
         <FormControl
           isInvalid={!!errors.image}
           errorMessage={errors.image ? errors.image.message : undefined}
+          w="full"
+          boxSize={{ base: "2xs", md: "24" }}
+          position="relative"
+          as={Center}
         >
           <Controller
             name="image"
             control={control}
             render={({ field: { ref, name, onChange, onBlur } }) => (
-              <Center
-                w="full"
-                boxSize={{ base: "2xs", md: "24" }}
-                position="relative"
-              >
+              <>
                 <Avatar
                   src={imagePreview}
                   boxSize={{ base: "2xs", md: "24" }}
@@ -178,7 +178,7 @@ export const ProfileForm: FC<ProfileForm> = ({ user }) => {
                     </MenuItem>
                   </MenuList>
                 </Menu>
-              </Center>
+              </>
             )}
           />
         </FormControl>

--- a/components/forms/profile-form.tsx
+++ b/components/forms/profile-form.tsx
@@ -1,0 +1,181 @@
+"use client"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { CameraIcon, FilePenLineIcon, TrashIcon } from "@yamada-ui/lucide"
+import {
+  Avatar,
+  Button,
+  Center,
+  ErrorMessage,
+  FileButton,
+  FormControl,
+  Heading,
+  HStack,
+  Label,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+  Textarea,
+  useSafeLayoutEffect,
+  VStack,
+  type FC,
+} from "@yamada-ui/react"
+import Link from "next/link"
+import { useState } from "react"
+import { Controller, useForm } from "react-hook-form"
+import type { getUserById } from "@/actions/user/user"
+import { FrontUserProfileSchema, UserIconSchema } from "@/schema/user"
+import type { FrontUserProfileForm } from "@/schema/user"
+
+interface ProfileForm {
+  user: Awaited<ReturnType<typeof getUserById>>
+}
+
+export const ProfileForm: FC<ProfileForm> = ({ user }) => {
+  const [imagePreview, setImagePreview] = useState<string>(user?.image || "")
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<FrontUserProfileForm>({
+    resolver: zodResolver(FrontUserProfileSchema),
+    defaultValues: {
+      profileText: user?.profileText || "",
+      image: user?.image || "",
+    },
+  })
+
+  const onSubmit = (data: FrontUserProfileForm) => {
+    console.log(data)
+  }
+
+  // watchでimagePathを監視
+  const image = watch("image") as unknown as FileList | null
+
+  const updateImage = async () => {
+    const { success, data } = await UserIconSchema.safeParseAsync(image)
+    if (success && data) {
+      setImagePreview(data)
+    }
+  }
+
+  const onResetImage = () => {
+    setValue("image", null)
+    setImagePreview("")
+  }
+
+  // 画像選択時にプレビューを更新
+  useSafeLayoutEffect(() => {
+    updateImage()
+  }, [image])
+
+  return (
+    <VStack
+      as="form"
+      onSubmit={handleSubmit(onSubmit)}
+      gap="md"
+      w="full"
+      maxW="3xl"
+      h="full"
+      m="auto"
+      p="md"
+    >
+      <HStack w="full" m="auto" flexDir={{ base: "row", sm: "column" }}>
+        <FormControl
+          isInvalid={!!errors.image}
+          errorMessage={errors.image ? errors.image.message : undefined}
+        >
+          <Controller
+            name="image"
+            control={control}
+            render={({ field: { ref, name, onChange, onBlur } }) => (
+              <Center
+                w="full"
+                boxSize={{ base: "2xs", md: "24" }}
+                position="relative"
+              >
+                <Avatar
+                  src={imagePreview}
+                  boxSize={{ base: "2xs", md: "24" }}
+                />
+                <Menu>
+                  <MenuButton
+                    as={Button}
+                    leftIcon={<FilePenLineIcon fontSize="2xl" />}
+                    colorScheme="riverBlue"
+                    isRounded
+                    position="absolute"
+                    bottom={0}
+                    right={0}
+                    size="sm"
+                  >
+                    編集
+                  </MenuButton>
+                  <MenuList>
+                    <MenuItem
+                      as={FileButton}
+                      variant="unstyled"
+                      {...{ ref, name, onChange, onBlur }}
+                      accept="image/*"
+                      onChange={onChange}
+                      leftIcon={<CameraIcon fontSize="xl" color="gray" />}
+                      justifyContent="start"
+                      size="sm"
+                    >
+                      ファイルを選択
+                    </MenuItem>
+                    <MenuItem
+                      color="red"
+                      as={Button}
+                      variant="unstyled"
+                      justifyContent="start"
+                      size="sm"
+                      leftIcon={<TrashIcon fontSize="xl" color="danger" />}
+                      onClick={onResetImage}
+                    >
+                      削除
+                    </MenuItem>
+                  </MenuList>
+                </Menu>
+              </Center>
+            )}
+          />
+        </FormControl>
+        <VStack maxW="xl">
+          <Heading fontSize="2xl">{user?.name}</Heading>
+          <HStack justifyContent="space-between" flexWrap="wrap">
+            <Text>{user?.studentNumber}</Text>
+          </HStack>
+        </VStack>
+      </HStack>
+      <FormControl
+        gap={{ base: "2xl", md: "md" }}
+        isInvalid={!!errors.profileText}
+        m="auto"
+      >
+        <Label flexGrow={1}>自己紹介</Label>
+        <VStack w="auto">
+          <Textarea
+            placeholder="説明を入力"
+            minH="md"
+            autosize
+            {...register("profileText")}
+          />
+          {errors.profileText ? (
+            <ErrorMessage mt={0}>{errors.profileText.message}</ErrorMessage>
+          ) : undefined}
+        </VStack>
+      </FormControl>
+      <Center gap="md" justifyContent="end">
+        <Button as={Link} href={`/user/${user?.id || ""}`}>
+          キャンセル
+        </Button>
+        <Button type="submit">更新</Button>
+      </Center>
+    </VStack>
+  )
+}

--- a/data/user.ts
+++ b/data/user.ts
@@ -1,5 +1,28 @@
 import { db } from "@/utils/db"
 
+export const updateUser = async (
+  userId: string,
+  profileText: string,
+  image: string,
+) =>
+  db.user.update({
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      image: true,
+      profileText: true,
+      studentNumber: true,
+    },
+    where: {
+      id: userId,
+    },
+    data: {
+      profileText,
+      image,
+    },
+  })
+
 export const getUsers = async () =>
   db.user.findMany({
     select: {

--- a/data/user.ts
+++ b/data/user.ts
@@ -1,5 +1,21 @@
 import { db } from "@/utils/db"
 
+export const getUsers = async () =>
+  db.user.findMany({
+    select: {
+      id: true,
+      image: true,
+      name: true,
+      profileText: true,
+      studentNumber: true,
+      CircleMember: {
+        include: {
+          circle: true,
+        },
+      },
+    },
+  })
+
 export const getUserByEmail = async (email: string) => {
   try {
     const user = await db.user.findUnique({

--- a/schema/user.ts
+++ b/schema/user.ts
@@ -30,6 +30,10 @@ export const FrontUserProfileSchema = UserProfileSchema.extend({
   image: UserIconSchema,
 }).brand<"FrontUserProfileSchema">()
 
+export type FrontUserProfileForm = z.infer<typeof FrontUserProfileSchema>
+
 export const BackUserProfileSchema = UserProfileSchema.extend({
   image: z.string().optional().nullable(),
 }).brand<"BackUserProfileSchema">()
+
+export type BackUserProfileForm = z.infer<typeof BackUserProfileSchema>

--- a/schema/user.ts
+++ b/schema/user.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+import { getBase64Image } from "@/utils/file"
+
+export const UserIconSchema = z
+  .custom<FileList>()
+  .optional() // 画像ファイルはオプション
+  .refine(
+    (file) =>
+      typeof file === "string" ||
+      !file ||
+      file.length === 0 ||
+      (file.length > 0 && file[0].type.startsWith("image/")),
+    {
+      message: "画像ファイルを選択してください",
+    },
+  )
+  .transform(async (file) => {
+    if (typeof file === "string" || !file || file.length === 0) {
+      return null // 画像がない場合はnullを返す
+    }
+    const selectedFile = file[0]
+    return await getBase64Image(selectedFile)
+  })
+
+export const UserProfileSchema = z.object({
+  profileText: z.string().optional(),
+})
+
+export const FrontUserProfileSchema = UserProfileSchema.extend({
+  image: UserIconSchema,
+}).brand<"FrontUserProfileSchema">()
+
+export const BackUserProfileSchema = UserProfileSchema.extend({
+  image: z.string().optional().nullable(),
+}).brand<"BackUserProfileSchema">()


### PR DESCRIPTION
Closes #19 
Closes #122 
 <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

- ホームからプロフィールへ遷移
- 自分自身の場合は編集画面へ
- 画像とテキストの編集が可能
- サークルのメンバー一覧からも遷移可能

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
