### PR TITLE
Fix/loading center

### DIFF
--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -141,7 +141,7 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
           </HStack>
           <VStack>
             {loading ? (
-              <Center w="full" h="full">
+              <Center w="full" h="xs">
                 <Loading fontSize="xl" />
               </Center>
             ) : activitys && activitys.length > 0 ? (
@@ -192,7 +192,7 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                 </GridItem>
               ))
             ) : (
-              <Center w="full">
+              <Center w="full" h="xs">
                 <Text>活動がありません</Text>
               </Center>
             )}

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -114,7 +114,7 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
   }
 
   return (
-    <VStack>
+    <VStack w="full" h="full">
       <Snacks snacks={snacks} />
       {currentActivity ? (
         <ActivityCard
@@ -139,9 +139,9 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
               }}
             />
           </HStack>
-          <VStack>
+          <VStack w="full" h="full">
             {loading ? (
-              <Center w="full" h="xs">
+              <Center w="full" h="full">
                 <Loading fontSize="xl" />
               </Center>
             ) : activitys && activitys.length > 0 ? (
@@ -192,7 +192,7 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                 </GridItem>
               ))
             ) : (
-              <Center w="full" h="xs">
+              <Center w="full" h="full">
                 <Text>活動がありません</Text>
               </Center>
             )}

--- a/components/data-display/circle-albums.tsx
+++ b/components/data-display/circle-albums.tsx
@@ -80,7 +80,7 @@ export const CircleAlbums: FC<CircleAlbums> = ({
     fetchData()
   }, [])
   return (
-    <VStack>
+    <VStack w="full" h="full">
       <Snacks snacks={snacks} />
       {currentAlbum ? (
         <AlbumCard
@@ -90,11 +90,11 @@ export const CircleAlbums: FC<CircleAlbums> = ({
           handleDelete={handleDelete}
         />
       ) : loading ? (
-        <Center w="full" h="350px">
+        <Center w="full" h="full">
           <Loading fontSize="xl" />
         </Center>
       ) : albums.length === 0 ? (
-        <Center w="full" h="350px">
+        <Center w="full" h="full">
           <Text>アルバムがありません</Text>
         </Center>
       ) : (

--- a/components/data-display/circle-albums.tsx
+++ b/components/data-display/circle-albums.tsx
@@ -90,11 +90,11 @@ export const CircleAlbums: FC<CircleAlbums> = ({
           handleDelete={handleDelete}
         />
       ) : loading ? (
-        <Center w="full" h="full">
+        <Center w="full" h="350px">
           <Loading fontSize="xl" />
         </Center>
       ) : albums.length === 0 ? (
-        <Center w="full">
+        <Center w="full" h="350px">
           <Text>アルバムがありません</Text>
         </Center>
       ) : (

--- a/components/data-display/circle-threads.tsx
+++ b/components/data-display/circle-threads.tsx
@@ -118,7 +118,7 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
     fetchData()
   }, [selectedOptions])
   return (
-    <VStack gap="md">
+    <VStack gap="md" w="full" h="full">
       <Snacks snacks={snacks} />
       {currentThread ? (
         <ThreadCard
@@ -152,7 +152,7 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
             <Option value="isImportant">重要</Option>
           </MultiSelect>
           {loading ? (
-            <Center w="full" h="xs">
+            <Center w="full" h="full">
               <Loading fontSize="xl" />
             </Center>
           ) : topics && topics.length > 0 ? (
@@ -169,7 +169,7 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
               ))}
             </VStack>
           ) : (
-            <Center w="full" h="xs">
+            <Center w="full" h="full">
               <Text>投稿がありません</Text>
             </Center>
           )}

--- a/components/data-display/circle-threads.tsx
+++ b/components/data-display/circle-threads.tsx
@@ -152,7 +152,7 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
             <Option value="isImportant">重要</Option>
           </MultiSelect>
           {loading ? (
-            <Center w="full" h="full">
+            <Center w="full" h="xs">
               <Loading fontSize="xl" />
             </Center>
           ) : topics && topics.length > 0 ? (
@@ -169,7 +169,7 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
               ))}
             </VStack>
           ) : (
-            <Center w="full">
+            <Center w="full" h="xs">
               <Text>投稿がありません</Text>
             </Center>
           )}

--- a/components/disclosure/circle-detail-tabs.tsx
+++ b/components/disclosure/circle-detail-tabs.tsx
@@ -54,7 +54,7 @@ export const CircleDetailTabs: FC<CircleDetailTabsProps> = ({
   const { data } = membershipRequests
 
   return (
-    <Tabs index={tabIndex}>
+    <Tabs index={tabIndex} w="full" h="full">
       <TabList overflowX="auto" overflowY="hidden">
         <Tab
           flexShrink={0}
@@ -86,8 +86,8 @@ export const CircleDetailTabs: FC<CircleDetailTabsProps> = ({
           </Indicator>
         </Tab>
       </TabList>
-      <TabPanels>
-        <TabPanel>
+      <TabPanels h="full">
+        <TabPanel h="full">
           <CircleActivitydays
             userId={userId}
             userRole={userRole}
@@ -97,7 +97,7 @@ export const CircleDetailTabs: FC<CircleDetailTabsProps> = ({
             circle={circle}
           />
         </TabPanel>
-        <TabPanel>
+        <TabPanel h="full">
           <CircleAlbums
             userId={userId}
             circleId={circle?.id || ""}
@@ -106,7 +106,7 @@ export const CircleDetailTabs: FC<CircleDetailTabsProps> = ({
             currentAlbum={currentAlbum}
           />
         </TabPanel>
-        <TabPanel>
+        <TabPanel h="full">
           <CircleThreads
             userId={userId}
             isAdmin={isAdmin}
@@ -117,7 +117,7 @@ export const CircleDetailTabs: FC<CircleDetailTabsProps> = ({
           />
         </TabPanel>
 
-        <TabPanel>
+        <TabPanel h="full">
           <CircleMembers
             userId={userId}
             userRole={userRole}

--- a/components/layouts/circle-detail-page.tsx
+++ b/components/layouts/circle-detail-page.tsx
@@ -51,7 +51,7 @@ export const CircleDetailPage: FC<{
   )
 
   return (
-    <VStack w="full" h="fit-content" gap={0} p={0}>
+    <VStack w="full" h="full" gap={0} p={0}>
       <VStack w="full" h="full" flexGrow={1} p={0}>
         <VStack
           {...(circle?.imagePath


### PR DESCRIPTION
Closes #132  <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
ローディングと「○○がありません」の配置を上下中央寄りに配置する
## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
活動日程と掲示板タブはheightをxsに変更
アルバムはheightをxsにするとフィルター等がない分、配置が上になるので
350px指定にして活動日程と掲示板タブと高さを合わせた

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
スマホのレイアウトとか見たら完全に中央の配置になってるわけではないので
気になるようであれば頑張って修正します！